### PR TITLE
Fix all_permissions function path

### DIFF
--- a/public/views/partials/lib/queries/role_permissions/get_all.liquid
+++ b/public/views/partials/lib/queries/role_permissions/get_all.liquid
@@ -26,11 +26,12 @@
   comment
     Superadmins should do everything.
   endcomment
-  function all_permissions = 'modules/permission/lib/queries/permission/get_all'
+  function all_permissions = 'modules/permission/get_permissions'
   assign role = '{}' | parse_json | hash_merge: role_name: 'superadmin', permissions: all_permissions
   assign roles = roles | prepend_to_array: role
+  
   comment
-    Decalre the default roles.
+    Declare the default roles.
   endcomment
   unless authenticated_declared
     assign no_permissions = '[]' | parse_json


### PR DESCRIPTION
The partial all_permissions is pointing to ('modules/permission/lib/queries/permission/get_all') is missing. Changing the path to 'modules/permission/get_permissions' seems to fix it. Although I think it may be better to instead add queries, commands, and hook folders in the permission module, and keep the original path as is.