### PR TITLE
Optional password validation when creating a session

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ function res = 'modules/user/lib/commands/session/destroy'
 
 These functions will fire `hook_user_login/logout` hooks.
 
+It's possible to skip password validation and just create a session and fire `hook_user_login` by set `validate_password` boolean to `false` when calling `sessions/create` command. In this case to have to set `user_id`.
+
+```
+function res = 'modules/user/lib/commands/session/create', user_id: '1', validate_password: false
+```
+
 There are also default rest handlers to create (`POST /user/sessions/create`) or destroy (`GET /sessions/destroy`) a session. You can modify the redirect path with a param called `redirect_to` or you can set `redirect_to` in `hook_user_login`
 
 ```

--- a/public/views/partials/lib/commands/session/create.liquid
+++ b/public/views/partials/lib/commands/session/create.liquid
@@ -1,24 +1,42 @@
 {% comment %}
   Creates a user sessions.
   Params:
-    - email: string
+    - user_id string (optional)
+    - validate_password boolean
+      default: true
+    - email: string (optional)
       the user's email address
-    - password: string
+    - password: string (optional)
       the user's password
     - hook_params: object
       the other params that will be passed to hook_user_login
 {% endcomment %}
 {% liquid
-  function user = 'modules/user/lib/commands/user/verify_password', email: email, password: password
-
-  if user.valid
-    function user = 'modules/user/lib/queries/user/load', id: user.id
-    hash_assign user['valid'] = true
-    sign_in_rc user_id: user.id
-    assign params = '{}' | parse_json | hash_merge: user: user, hook_params: hook_params
-    function results = 'modules/core/lib/commands/hook/fire', hook: 'user_login', params: params, merge_to_object: true
-    hash_assign user['hook_results'] = results
+  if validate_password == nil
+    assign validate_password = true
   endif
 
-  return user
+  if validate_password
+    function user = 'modules/user/lib/commands/user/verify_password', email: email, password: password
+    unless user.valid
+      return user
+    endunless
+    assign user_id = user.id
+  endif
+
+  function object = 'modules/user/lib/commands/session/create/build', id: user_id
+  function object = 'modules/user/lib/commands/session/create/check', object: object
+
+  if object.valid
+    function user = 'modules/user/lib/queries/user/load', id: object.id
+    if user.id
+      sign_in_rc user_id: user.id
+      assign params = '{}' | parse_json | hash_merge: user: user, hook_params: hook_params
+      function results = 'modules/core/lib/commands/hook/fire', hook: 'user_login', params: params, merge_to_object: true
+      hash_assign user['hook_results'] = results
+    endif
+    hash_assign object['user'] = user
+  endif
+
+  return object
 %}

--- a/public/views/partials/lib/commands/session/create/build.liquid
+++ b/public/views/partials/lib/commands/session/create/build.liquid
@@ -1,0 +1,7 @@
+{% parse_json object %}
+  {
+    "id": {{ id | json }}
+  }
+{% endparse_json %}
+
+{% return object %}

--- a/public/views/partials/lib/commands/session/create/check.liquid
+++ b/public/views/partials/lib/commands/session/create/check.liquid
@@ -1,0 +1,10 @@
+{% liquid
+  assign c = '{ "errors": {}, "valid": true }' | parse_json
+
+  function c = 'modules/core/lib/validations/presence', c: c, object: object, field_name: 'id', key: 'validation.blank'
+
+  hash_assign object['valid'] = c.valid
+  hash_assign object['errors'] = c.errors
+
+  return object
+%}


### PR DESCRIPTION
# Description

If we want to create a session for a user but we don't want to know the password (for example we want to create a session right after the registration) we can do it in `hook_user_create` but as we don't want to repeat user's module code in the custom hook (for example firing `hook_user_login`), we should use user's module `session/create` command to handle this scenario too.

## Issue ticket number and link

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
