### PR TITLE
Render only available labels and add placeholder to config

### DIFF
--- a/modules/user/public/views/partials/users/new.liquid
+++ b/modules/user/public/views/partials/users/new.liquid
@@ -20,8 +20,10 @@ metadata:
     <input type="hidden" name="authenticity_token" value="{{ context.authenticity_token }}">
     {% for field in registration_fields %}
       <fieldset>
-        <label for="pos-user-{{ field.name }}">{{ field.label }}</label>
-        <input type="{{ field.type }}" name="{{ field.name }}" id="pos-user-{{ field.name }}" value="{{ values[field.name] }}" required placeholder="{{ field.label | downcase }}"{% render 'modules/common-styling/forms/error_input_handler', name: '{{field.name}}', errors: errors[field.name] %}>
+        {% if field.label %}
+          <label for="pos-user-{{ field.name }}">{{ field.label }}</label>
+        {% endif %}
+        <input type="{{ field.type }}" name="{{ field.name }}" id="pos-user-{{ field.name }}" value="{{ values[field.name] }}" required placeholder="{{ field.placeholder }}"{% render 'modules/common-styling/forms/error_input_handler', name: field.name, errors: errors[field.name] %}>
         {% render 'modules/common-styling/forms/error_list', name: 'email', errors: errors['email'] %}
       </fieldset>
     {% endfor %}

--- a/modules/user/template-values.json
+++ b/modules/user/template-values.json
@@ -2,7 +2,7 @@
   "name": "User",
   "machine_name": "user",
   "type": "module",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "dependencies": {
     "core": "^1.5.0",
     "common-styling": "^1.2.0"


### PR DESCRIPTION
- Render only labels that are defined in the config
- Use `placeholder` from the config to render placeholders instead of duplicating the label in inputs